### PR TITLE
Crear teorías de cambio

### DIFF
--- a/migrations/versions/fc5c0dfff529_.py
+++ b/migrations/versions/fc5c0dfff529_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 47e24ce76c7b
+Revision ID: fc5c0dfff529
 Revises: 
-Create Date: 2026-01-26 23:35:41.444388
+Create Date: 2026-01-28 14:33:36.684197
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '47e24ce76c7b'
+revision = 'fc5c0dfff529'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -45,11 +45,6 @@ def upgrade():
     sa.PrimaryKeyConstraint('id_rol'),
     sa.UniqueConstraint('name_rol')
     )
-    op.create_table('theory_template',
-    sa.Column('id', sa.Integer(), nullable=False),
-    sa.Column('name', sa.String(length=100), nullable=False),
-    sa.PrimaryKeyConstraint('id')
-    )
     op.create_table('location',
     sa.Column('id_location', sa.Integer(), nullable=False),
     sa.Column('province', sa.String(length=100), nullable=False),
@@ -60,12 +55,11 @@ def upgrade():
     sa.ForeignKeyConstraint(['project_id'], ['project.id_project'], ),
     sa.PrimaryKeyConstraint('id_location')
     )
-    op.create_table('result_template',
+    op.create_table('theory_template',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('name', sa.String(length=100), nullable=False),
-    sa.Column('type', sa.Enum('output', 'outcome', name='result_types'), nullable=False),
-    sa.Column('theory_id', sa.Integer(), nullable=False),
-    sa.ForeignKeyConstraint(['theory_id'], ['theory_template.id'], ),
+    sa.Column('competence_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['competence_id'], ['competence.id_competence'], ),
     sa.PrimaryKeyConstraint('id')
     )
     op.create_table('user',
@@ -83,15 +77,6 @@ def upgrade():
     sa.PrimaryKeyConstraint('id_user'),
     sa.UniqueConstraint('email')
     )
-    op.create_table('indicator_template',
-    sa.Column('id', sa.Integer(), nullable=False),
-    sa.Column('code', sa.String(length=20), nullable=False),
-    sa.Column('description', sa.Text(), nullable=False),
-    sa.Column('result_id', sa.Integer(), nullable=False),
-    sa.ForeignKeyConstraint(['result_id'], ['result_template.id'], ),
-    sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('code')
-    )
     op.create_table('project_competence',
     sa.Column('id_pc', sa.Integer(), nullable=False),
     sa.Column('project_id', sa.Integer(), nullable=False),
@@ -102,12 +87,29 @@ def upgrade():
     sa.ForeignKeyConstraint(['project_id'], ['project.id_project'], ),
     sa.PrimaryKeyConstraint('id_pc')
     )
+    op.create_table('result_template',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('name', sa.String(length=100), nullable=False),
+    sa.Column('type', sa.Enum('output', 'outcome', name='result_types'), nullable=False),
+    sa.Column('theory_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['theory_id'], ['theory_template.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
     op.create_table('user_competence',
     sa.Column('user_id', sa.Integer(), nullable=False),
     sa.Column('competence_id', sa.Integer(), nullable=False),
     sa.ForeignKeyConstraint(['competence_id'], ['competence.id_competence'], ),
     sa.ForeignKeyConstraint(['user_id'], ['user.id_user'], ),
     sa.PrimaryKeyConstraint('user_id', 'competence_id')
+    )
+    op.create_table('indicator_template',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('code', sa.String(length=20), nullable=False),
+    sa.Column('description', sa.Text(), nullable=False),
+    sa.Column('result_id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['result_id'], ['result_template.id'], ),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('code')
     )
     op.create_table('indicator',
     sa.Column('id_indicator', sa.Integer(), nullable=False),
@@ -157,13 +159,13 @@ def downgrade():
     op.drop_table('indicator_location_goal')
     op.drop_table('activity')
     op.drop_table('indicator')
-    op.drop_table('user_competence')
-    op.drop_table('project_competence')
     op.drop_table('indicator_template')
-    op.drop_table('user')
+    op.drop_table('user_competence')
     op.drop_table('result_template')
-    op.drop_table('location')
+    op.drop_table('project_competence')
+    op.drop_table('user')
     op.drop_table('theory_template')
+    op.drop_table('location')
     op.drop_table('rol')
     op.drop_table('project')
     op.drop_table('competence')

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -96,22 +96,43 @@ class TheoryTemplate(db.Model):
     __tablename__ = 'theory_template'
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
-    results: Mapped[List["ResultTemplate"]
-                    ] = relationship(back_populates="theory")
+    
+    # Asegúrate de que el nombre aquí coincida con el primary_key de Competence
+    competence_id: Mapped[int] = mapped_column(ForeignKey('competence.id_competence'), nullable=False)
+    
+    # Relación bidireccional (Añadido back_populates)
+    competence: Mapped["Competence"] = relationship(backref="theories") 
+
+    results: Mapped[List["ResultTemplate"]] = relationship(back_populates="theory", cascade="all, delete-orphan")
+    
+    def serialize(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "competence_id": self.competence_id,
+            "competence_name": self.competence.name if self.competence else None
+        }
 
 
 class ResultTemplate(db.Model):
     __tablename__ = 'result_template'
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
-    # Define si es Output u Outcome
     type: Mapped[str] = mapped_column(
         Enum('output', 'outcome', name='result_types'), nullable=False)
 
     theory_id: Mapped[int] = mapped_column(ForeignKey('theory_template.id'))
     theory: Mapped["TheoryTemplate"] = relationship(back_populates="results")
-    indicators: Mapped[List["IndicatorTemplate"]
-                       ] = relationship(back_populates="result")
+    indicators: Mapped[List["IndicatorTemplate"]] = relationship(back_populates="result", cascade="all, delete-orphan")
+
+    # ¡IMPORTANTE! Añadir serialize para el siguiente paso del proyecto
+    def serialize(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "type": self.type,
+            "theory_id": self.theory_id
+        }
 
 
 class IndicatorTemplate(db.Model):

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -2,7 +2,7 @@
 This module takes care of starting the API Server, Loading the DB and Adding the endpoints
 """
 from flask import Flask, request, jsonify, url_for, Blueprint
-from api.models import db, User, Rol, Competence
+from api.models import db, User, Rol, Competence, TheoryTemplate
 from api.utils import generate_sitemap, APIException,  val_email, val_password, generate_reset_token, confirm_reset_token
 from flask_cors import CORS
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -641,3 +641,59 @@ def assign_user_competences(user_id):
     except Exception as error:
         db.session.rollback()
         return jsonify({"message": "Error assigning competences", "error": str(error)}), 500
+
+
+@api.route('/theories', methods=['GET'])
+@jwt_required()
+def get_theories():
+    theories = TheoryTemplate.query.all()
+    # Al serializar, ya incluimos el nombre de la competencia gracias al modelo
+    return jsonify([t.serialize() for t in theories]), 200
+
+
+@api.route('/theories', methods=['POST'])
+@manager_required
+def create_theory():
+    data = request.json
+    name = data.get("name")
+    competence_id = data.get("competence_id")
+
+    if not name or not competence_id:
+        return jsonify({"message": "Nombre y ID de competencia son obligatorios"}), 400
+
+    # Verificamos que la competencia exista
+    if not Competence.query.get(competence_id):
+        return jsonify({"message": "La competencia especificada no existe"}), 404
+
+    new_theory = TheoryTemplate(name=name, competence_id=competence_id)
+    db.session.add(new_theory)
+    db.session.commit()
+    
+    return jsonify(new_theory.serialize()), 201
+
+
+@api.route('/theories/<int:id>', methods=['PUT'])
+@manager_required
+def update_theory(id):
+    theory = TheoryTemplate.query.get(id)
+    if not theory:
+        return jsonify({"message": "Teoría no encontrada"}), 404
+
+    data = request.json
+    theory.name = data.get("name", theory.name)
+    theory.competence_id = data.get("competence_id", theory.competence_id)
+    
+    db.session.commit()
+    return jsonify(theory.serialize()), 200
+
+
+@api.route('/theories/<int:id>', methods=['DELETE'])
+@manager_required
+def delete_theory(id):
+    theory = TheoryTemplate.query.get(id)
+    if not theory:
+        return jsonify({"message": "Teoría no encontrada"}), 404
+
+    db.session.delete(theory)
+    db.session.commit()
+    return jsonify({"message": "Teoría de cambio eliminada"}), 200

--- a/src/front/pages/TheoryManagement.jsx
+++ b/src/front/pages/TheoryManagement.jsx
@@ -1,0 +1,194 @@
+import React, { useEffect, useState } from "react";
+import { toast, Toaster } from "sonner";
+import Swal from 'sweetalert2';
+import { apiFetch } from "../../utils/api";
+import "../styles/auth.css";
+import "../styles/roleManagement.css";
+import "../styles/theoryManagement.css";
+
+const TheoryManagement = () => {
+    const [theories, setTheories] = useState([]);
+    const [competences, setCompetences] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    const fetchData = async () => {
+        try {
+            const [resTheories, resComps] = await Promise.all([
+                apiFetch("/theories"),
+                apiFetch("/competences")
+            ]);
+
+            if (resTheories?.ok && resComps?.ok) {
+                const dataTheories = await resTheories.json();
+                const dataComps = await resComps.json();
+                setTheories(dataTheories);
+                setCompetences(dataComps);
+            }
+        } catch (error) {
+            toast.error("Error al cargar los datos");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => { fetchData(); }, []);
+
+    // 2. Mejoramos el modal para recibir una competencia por defecto
+    const handleOpenModal = async (theory = null, defaultCompId = null) => {
+        const isEditing = !!theory;
+        const initialCompId = isEditing ? theory.competence_id : (defaultCompId || "");
+
+        const { value: formValues } = await Swal.fire({
+            title: isEditing ? 'Editar Teoría' : 'Nueva Teoría de Cambio',
+            background: 'var(--card-bg)',
+            color: 'var(--text-primary)',
+            html: `
+    <div class="mt-3 text-start">
+        <label class="form-label management-subtitle">Nombre de la Teoría</label>
+        <input id="swal-input-name" class="swal2-input custom-swal-input" 
+               placeholder="Ej. Fortalecimiento institucional" 
+               value="${isEditing ? theory.name : ''}">
+        
+        <label class="form-label management-subtitle mt-3">Competencia Asociada</label>
+        <select id="swal-input-comp" class="swal2-select custom-swal-input">
+            <option value="" disabled ${!initialCompId ? 'selected' : ''}>Seleccione una competencia...</option>
+            ${competences.map(c => `
+                <option value="${c.id}" ${initialCompId == c.id ? 'selected' : ''} style="color: black;">
+                    ${c.name}
+                </option>
+            `).join('')}
+        </select>
+    </div>
+`,
+            showCancelButton: true,
+            confirmButtonText: isEditing ? 'Actualizar' : 'Guardar',
+            confirmButtonColor: '#10b981', // Emerald Green para éxito
+            preConfirm: () => {
+                const name = document.getElementById('swal-input-name').value;
+                const competence_id = document.getElementById('swal-input-comp').value;
+                if (!name || !competence_id) {
+                    Swal.showValidationMessage('Todos los campos son obligatorios');
+                }
+                return { name, competence_id };
+            }
+        });
+
+        if (formValues) {
+            try {
+                const method = isEditing ? "PUT" : "POST";
+                const endpoint = isEditing ? `/theories/${theory.id}` : "/theories";
+                const res = await apiFetch(endpoint, {
+                    method: method,
+                    body: JSON.stringify(formValues)
+                });
+
+                if (res?.ok) {
+                    toast.success("Operación exitosa");
+                    fetchData(); // 3. Esto reubica automáticamente la teoría
+                }
+            } catch (error) {
+                toast.error("Error de conexión");
+            }
+        }
+    };
+
+    const handleDelete = async (theory) => {
+        const result = await Swal.fire({
+            title: '¿Eliminar Teoría?',
+            text: `Se eliminará "${theory.name}"`,
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#ef4444',
+            background: 'var(--card-bg)',
+            color: 'var(--text-primary)'
+        });
+
+        if (result.isConfirmed) {
+            const res = await apiFetch(`/theories/${theory.id}`, { method: "DELETE" });
+            if (res?.ok) {
+                toast.success("Eliminado");
+                fetchData();
+            }
+        }
+    };
+
+    if (loading) return <div className="spinner-border text-emerald m-5"></div>;
+
+    return (
+        <div className="management-page-container theory-page-wrapper p-4">
+            <Toaster richColors />
+            <div className="container">
+                <div className="mb-4">
+                    <h2 className="management-title">Gestión de Teorías</h2>
+                    <p className="management-subtitle">Estructura jerárquica por competencias</p>
+                </div>
+
+                {competences.map(comp => {
+                    const filteredTheories = theories.filter(t => t.competence_id === comp.id);
+
+                    return (
+                        // CAMBIO: Usamos theory-section-card en lugar de bg-dark
+                        <div key={comp.id} className="theory-section-card mb-5">
+
+                            {/* CAMBIO: Header con clase personalizada */}
+                            <div className="theory-section-header py-2">
+                                <h5 className="mb-0">
+                                    <i className="fas fa-layer-group me-2 text-emerald"></i>
+                                    Competencia: {comp.name}
+                                </h5>
+                                <button
+                                    className="btn btn-sm btn-add-theory"
+                                    onClick={() => handleOpenModal(null, comp.id)}
+                                >
+                                    <i className="fas fa-plus me-1"></i> Agregar a {comp.name}
+                                </button>
+                            </div>
+
+                            <div className="card-body p-0">
+                                {/* CAMBIO: Quitamos table-light de thead y usamos theory-table */}
+                                <table className="table table-sigssep theory-table mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th className="ps-4" style={{ width: '100px' }}>ID</th>
+                                            <th>TEORÍA DE CAMBIO</th>
+                                            <th className="text-end pe-4">ACCIONES</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {filteredTheories.length > 0 ? (
+                                            filteredTheories.map(t => (
+                                                <tr key={t.id} className="theory-row">
+                                                    {/* CAMBIO: Usamos text-primary con opacidad para el ID */}
+                                                    <td className="ps-4 small" style={{ color: 'var(--text-primary)', opacity: 0.6 }}>
+                                                        #{t.id}
+                                                    </td>
+                                                    <td className="fw-bold">{t.name}</td>
+                                                    <td className="text-end pe-4">
+                                                        <button className="btn btn-sm btn-link text-info me-2" onClick={() => handleOpenModal(t)}>
+                                                            <i className="fas fa-edit"></i>
+                                                        </button>
+                                                        <button className="btn btn-sm btn-link text-danger" onClick={() => handleDelete(t)}>
+                                                            <i className="fas fa-trash-alt"></i>
+                                                        </button>
+                                                    </td>
+                                                </tr>
+                                            ))
+                                        ) : (
+                                            <tr>
+                                                <td colSpan="3" className="text-center py-4" style={{ color: 'var(--text-primary)', opacity: 0.5 }}>
+                                                    No hay teorías registradas para esta competencia.
+                                                </td>
+                                            </tr>
+                                        )}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+export default TheoryManagement;

--- a/src/front/routes.jsx
+++ b/src/front/routes.jsx
@@ -14,10 +14,11 @@ import { Login } from "./pages/Login";
 import { AccessDenied } from "./components/AccessDenied";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
-import UserManagement from "./pages/UserManagement"; 
+import UserManagement from "./pages/UserManagement";
 import RoleManagement from "./pages/RoleManagement";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import CompetenceManagement from "./pages/CompetenceManagement";
+import TheoryManagement from "./pages/TheoryManagement";
 import Profile from "./pages/Profile";
 
 export const router = createBrowserRouter(
@@ -63,6 +64,15 @@ export const router = createBrowserRouter(
         element={
           <ProtectedRoute>
             <CompetenceManagement />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/manager/theories"
+        element={
+          <ProtectedRoute>
+            <TheoryManagement />
           </ProtectedRoute>
         }
       />

--- a/src/front/styles/theoryManagement.css
+++ b/src/front/styles/theoryManagement.css
@@ -1,0 +1,109 @@
+/* theoryManagement.css - Versión Optimizada */
+
+/* 1. ANIMACIÓN (Definida una sola vez al inicio) */
+@keyframes fadeInUp {
+    from { 
+        opacity: 0; 
+        transform: translateY(20px); 
+    }
+    to { 
+        opacity: 1; 
+        transform: translateY(0); 
+    }
+}
+
+/* 2. TÍTULOS DE LA PÁGINA (Con candado para no afectar a Usuarios/Roles) */
+.theory-page-wrapper .management-title {
+    color: var(--text-primary) !important;
+    font-weight: 800;
+    font-size: 2rem; /* Un poco más grande para que destaque */
+    margin-bottom: 0.2rem;
+    display: block; /* Asegura que tome su espacio */
+}
+
+.theory-page-wrapper .management-subtitle {
+    color: var(--text-primary) !important;
+    opacity: 0.8; /* Subimos un poco la opacidad para que no se pierda */
+    font-size: 1.1rem;
+}
+
+/* 5. TABLA CON ENCABEZADO GRIS SÓLIDO */
+.theory-page-wrapper .theory-table th {
+    /* Cambiamos el transparente por un gris sólido suave */
+    background-color: #f8f9fa !important; 
+    color: #1b263b !important; /* Texto oscuro para contraste en light mode */
+    border-bottom: 2px solid var(--accent-color) !important;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    padding: 0.8rem 1.2rem !important; 
+}
+
+/* Ajuste para el encabezado en MODO OSCURO */
+[data-theme="dark"] .theory-page-wrapper .theory-table th {
+    background-color: #252d3d !important; /* Un gris azulado oscuro para el fondo */
+    color: #ffffff !important; /* Texto blanco */
+}
+
+/* 3. TARJETAS DE COMPETENCIA */
+.theory-page-wrapper .theory-section-card {
+    background-color: var(--card-bg) !important;
+    border-radius: 15px;
+    border: 1px solid rgba(128, 128, 128, 0.1);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    margin-bottom: 2.5rem;
+    animation: fadeInUp 0.6s ease backwards;
+}
+
+/* Efecto Cascada para las primeras 3 tarjetas */
+.theory-page-wrapper .theory-section-card:nth-child(1) { animation-delay: 0.1s; }
+.theory-page-wrapper .theory-section-card:nth-child(2) { animation-delay: 0.2s; }
+.theory-page-wrapper .theory-section-card:nth-child(3) { animation-delay: 0.3s; }
+
+/* 4. ENCABEZADO DE COMPETENCIA (Azul Oxford) */
+.theory-page-wrapper .theory-section-header {
+    background-color: #1b263b !important; 
+    color: #ffffff !important;
+    padding: 1rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+/* 5. TABLA COMPACTA (Eje Y reducido) */
+.theory-page-wrapper .theory-table {
+    background-color: transparent !important;
+    margin-bottom: 0;
+}
+
+.theory-page-wrapper .theory-table td {
+    color: var(--text-primary) !important;
+    border-bottom: 1px solid rgba(128, 128, 128, 0.1) !important;
+    padding: 0.6rem 1.2rem !important;
+    vertical-align: middle;
+}
+
+/* 6. BOTONES Y ACCIONES */
+.theory-page-wrapper .btn-add-theory {
+    background-color: rgba(82, 183, 136, 0.2);
+    color: #52b788 !important;
+    border: 1px solid #52b788;
+    font-weight: 600;
+    transition: all 0.3s ease;
+}
+
+.theory-page-wrapper .btn-add-theory:hover {
+    background-color: #52b788;
+    color: #0d1b2a !important;
+}
+
+.theory-page-wrapper .theory-row:hover {
+    background-color: rgba(82, 183, 136, 0.05) !important;
+}
+
+/* Limpieza de botones tipo link para que no estiren la fila */
+.theory-page-wrapper .btn-link {
+    padding: 0 5px !important;
+    line-height: 1;
+    text-decoration: none;
+}


### PR DESCRIPTION
Se agregaron los endpoints necesarios para ver, crear, editar y eliminar una teoría de cambio
Se creó el componente para ver las teorías de cambio según su competencia, y a su vez poderlas agregar, editar o eliminar.
Todo se ajustó al modo claro y oscuro.